### PR TITLE
refactor(core): implement type-safe validation with req.validatedData

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -7,7 +7,7 @@ import { AppError } from "../errors/AppError";
 export class AuthController {
   static async register(req: Request, res: Response, next: NextFunction) {
     try {
-      const { email, password, firstName, lastName }: UserRegister = req.body;
+      const { email, password, firstName, lastName } = req.validatedData?.body as UserRegister;
 
       const result = await AuthService.register({
         email,
@@ -32,7 +32,7 @@ export class AuthController {
 
   static async login(req: Request, res: Response, next: NextFunction) {
     try {
-      const { email, password }: UserLogin = req.body;
+      const { email, password } = req.validatedData?.body as UserLogin;
 
       const result = await AuthService.login({ email, password });
 

--- a/src/controllers/products.ts
+++ b/src/controllers/products.ts
@@ -7,7 +7,7 @@ import { AppError } from "../errors/AppError";
 export class ProductsController {
   static async getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      const filters: ProductsFilters = req.query;
+      const filters = req.validatedData?.query as ProductsFilters;
 
       const result = await ProductsService.getAll(filters);
 
@@ -27,9 +27,9 @@ export class ProductsController {
 
   static async getById(req: Request, res: Response, next: NextFunction) {
     try {
-      const { id } = req.params;
+      const { id } = req.validatedData?.params as { id: string };
 
-      const result = await ProductsService.getById(id as string);
+      const result = await ProductsService.getById(id);
 
       if (!result.ok) {
         let status = 500;
@@ -53,7 +53,7 @@ export class ProductsController {
 
   static async create(req: Request, res: Response, next: NextFunction) {
     try {
-      const newProduct: ProductPost = req.body;
+      const newProduct = req.validatedData?.body as ProductPost;
 
       const result = await ProductsService.create(newProduct);
 
@@ -76,9 +76,9 @@ export class ProductsController {
 
   static async delete(req: Request, res: Response, next: NextFunction) {
     try {
-      const { id } = req.params;
+      const { id } = req.validatedData?.params as { id: string };
 
-      const result = await ProductsService.delete(id as string);
+      const result = await ProductsService.delete(id);
 
       if (!result.ok) {
         let status = 500;
@@ -102,10 +102,10 @@ export class ProductsController {
 
   static async update(req: Request, res: Response, next: NextFunction) {
     try {
-      const { id } = req.params;
-      const productData: ProductPatch = req.body;
+      const { id } = req.validatedData?.params as { id: string };
+      const productData = req.validatedData?.body as ProductPatch;
 
-      const result = await ProductsService.update(id as string, productData);
+      const result = await ProductsService.update(id, productData);
 
       if (!result.ok) {
         let status = 500;
@@ -129,10 +129,10 @@ export class ProductsController {
 
   static async replace(req: Request, res: Response, next: NextFunction) {
     try {
-      const { id } = req.params;
+      const { id } = req.validatedData?.params as { id: string };
+      const productData = req.validatedData?.body as ProductPost;
 
-      const productData: ProductPost = req.body;
-      const result = await ProductsService.replace(id as string, productData);
+      const result = await ProductsService.replace(id, productData);
 
       if (!result.ok) {
         let status = 500;

--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -10,7 +10,7 @@ export const validateRequest = (schema: ZodObject<any>) => {
         query: req.query,
       });
 
-      Object.assign(req, parsed);
+      req.validatedData = parsed;
 
       return next();
     } catch (error) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -8,6 +8,11 @@ declare global {
         user: PublicUser | null;
       };
       params: { id?: number | string };
+      validatedData?: {
+        body?: unknown;
+        params?: unknown;
+        query?: unknown;
+      };
     }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,3 @@ export * from "./result";
 export * from "./errors";
 export * from "./user";
 export * from "./auth";
-export * from "./products";

--- a/tests/unit/middlewares/validateRequest.test.ts
+++ b/tests/unit/middlewares/validateRequest.test.ts
@@ -19,9 +19,10 @@ const mockRequest = (data: { body?: any; params?: any; query?: any }) => {
     body: data.body || {},
     params: data.params || {},
     query: data.query || {},
+    validatedData: undefined,
   };
 
-  return req as Request;
+  return req;
 };
 
 const mockResponse = () => ({}) as Response;
@@ -39,11 +40,17 @@ describe("Middleware: validateRequest", () => {
       query: { page: "2" },
     });
 
-    validationMiddleware(req, mockResponse(), mockNext);
+    validationMiddleware(req as unknown as Request, mockResponse(), mockNext);
 
     expect(mockNext).toHaveBeenCalledTimes(1);
     expect(mockNext).toHaveBeenCalledWith();
-    expect(req.body.name).toBe("John");
+
+    expect(req.query.page).toBe("2");
+    expect(req.validatedData).toEqual({
+      body: { name: "John" },
+      params: { id: "f8bbe5d8-4b45-48da-a0f1-c64484bb8426" },
+      query: { page: 2 },
+    });
   });
 
   test("Debe llamar a next() con ZodError si la validacion falla", () => {
@@ -53,7 +60,7 @@ describe("Middleware: validateRequest", () => {
       query: { page: 2 },
     });
 
-    validationMiddleware(req, mockResponse(), mockNext);
+    validationMiddleware(req as unknown as Request, mockResponse(), mockNext);
 
     expect(mockNext).toHaveBeenCalledTimes(1);
     expect(mockNext).toHaveBeenCalledWith(expect.any(ZodError));


### PR DESCRIPTION
## Description

This pull request addresses a critical bug in the core `validateRequest` middleware. The previous implementation caused 500 errors (`Cannot set property query...`) by attempting to mutate Express's read-only `req.query` object.

It also failed to pass correctly coerced types (e.g., from `z.coerce.number()`) to the controllers, resulting in type mismatches (string vs. number).

This PR refactors the validation logic to use a new, type-safe `req.validatedData` property, which fixes both issues and improves the overall architecture.

## Key Changes

### 1. Middleware Refactor
* The `validateRequest` middleware no longer mutates `req.body`, `req.params`, or `req.query`.
* It now attaches all parsed, coerced, and validated data to a new `req.validatedData` property.

### 2. Type-Safety & Integration
* Updated `express.d.ts` to include the `validatedData: { body?: unknown, params?: unknown, query?: unknown }` property on the `Request` interface for type-safety.
* Refactored `AuthController` and `ProductsController` to read all validated inputs exclusively from `req.validatedData`. This ensures they receive the correct, coerced types.

### 3. Test Updates
* The unit test for `validateRequest` (`validateRequest.test.ts`) has been updated to assert the new behavior: it now checks that `req.validatedData` is correctly populated and that the original `req.query` remains untouched.