### PR TITLE
feat(users): Implement user profile management endpoints

### DIFF
--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import { UsersService } from "../services/users";
+import { PatchUserInput } from "../schemas/users";
+
+export class UsersController {
+  static async getProfile(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const result = await UsersService.getProfile(userId);
+
+      return res.json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async updateProfile(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const updateData = req.validatedData!.body as PatchUserInput;
+
+      const result = await UsersService.updateProfile(userId, updateData);
+
+      return res.json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async deleteUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+
+      await UsersService.deleteUser(userId);
+
+      return res.status(204).send();
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -1,0 +1,24 @@
+import { Prisma } from "@prisma/client";
+import { PatchUserInput } from "../schemas/users";
+import { prisma } from "../utils/prismaClient";
+
+export class UsersModel {
+  static async getProfile(userId: string) {
+    return await prisma.user.findUnique({ where: { id: userId } });
+  }
+
+  static async getByEmail(email: string) {
+    return await prisma.user.findUnique({ where: { email } });
+  }
+
+  static async updateProfile(userId: string, newData: PatchUserInput) {
+    return await prisma.user.update({
+      where: { id: userId },
+      data: newData as Prisma.UserUpdateInput,
+    });
+  }
+
+  static async delete(userId: string) {
+    return await prisma.user.delete({ where: { id: userId } });
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import authRoutes from "./auth";
+import usersRoutes from "./users";
 import productsRoutes from "./products";
 import categoriesRouter from "./categories";
 import cartRouter from "./cart";
@@ -8,6 +9,7 @@ import ordersRouter from "./orders";
 const router = Router()
 
 router.use('/auth', authRoutes)
+router.use('/users', usersRoutes)
 router.use('/products', productsRoutes)
 router.use('/categories', categoriesRouter)
 router.use('/cart', cartRouter)

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { isAuthenticated } from "../middlewares/isAuthenticated";
+import { UsersController } from "../controllers/users";
+import { validateRequest } from "../middlewares/validateRequest";
+import { patchUserSchemaValidation } from "../schemas/users";
+
+const router = Router();
+
+router.get("/me", isAuthenticated, UsersController.getProfile);
+
+router.patch(
+  "/me",
+  isAuthenticated,
+  validateRequest(patchUserSchemaValidation),
+  UsersController.updateProfile
+);
+
+router.delete("/me", isAuthenticated, UsersController.deleteUser);
+
+export default router;

--- a/src/schemas/users/index.ts
+++ b/src/schemas/users/index.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const patchUserSchema = z
+  .object({
+    firstName: z
+      .string()
+      .min(1, "El nombre debe tener entre 1 y 100 caracteres")
+      .max(100, "El nombre debe tener entre 1 y 100 caracteres"),
+    lastName: z
+      .string()
+      .min(1, "El apellido debe tener entre 1 y 100 caracteres")
+      .max(100, "El apellido debe tener entre 1 y 100 caracteres"),
+    email: z.email("El correo electrónico no es válido"),
+  })
+  .partial();
+
+export const patchUserSchemaValidation = z.object({
+  body: patchUserSchema,
+});
+
+export type PatchUserInput = z.infer<typeof patchUserSchema>;

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,0 +1,44 @@
+import { AppError } from "../errors/AppError";
+import { UsersModel } from "../models/users";
+import { PatchUserInput } from "../schemas/users";
+
+export class UsersService {
+  static async getProfile(userId: string) {
+    const user = await UsersModel.getProfile(userId);
+    if (!user) {
+      throw new AppError("Usuario no encontrado", 404);
+    }
+
+    const { passwordHash, ...userDto } = user;
+
+    return userDto;
+  }
+
+  static async updateProfile(userId: string, newData: PatchUserInput) {
+    const existingUser = await UsersModel.getProfile(userId);
+    if (!existingUser) {
+      throw new AppError("Usuario no encontrado", 404);
+    }
+
+    if (newData.email && newData.email !== existingUser.email) {
+      const emailTaken = await UsersModel.getByEmail(newData.email);
+      if (emailTaken) {
+        throw new AppError("El correo electrónico ya está en uso", 409);
+      }
+    }
+
+    const updatedUser = await UsersModel.updateProfile(userId, newData);
+    const { passwordHash, ...userDto } = updatedUser;
+
+    return userDto;
+  }
+
+  static async deleteUser(userId: string) {
+    const existingUser = await UsersModel.getProfile(userId);
+    if (!existingUser) {
+      throw new AppError("Usuario no encontrado", 404);
+    }
+
+    return await UsersModel.delete(userId);
+  }
+}

--- a/tests/integration/users.test.ts
+++ b/tests/integration/users.test.ts
@@ -1,0 +1,225 @@
+import request from "supertest";
+import { Request, Response, NextFunction } from "express";
+import { Role } from "@prisma/client";
+import app from "../../src/app";
+import { prisma } from "../../src/utils/prismaClient";
+import { AppError } from "../../src/errors/AppError";
+
+// --- Mocking Dependencias ---
+jest.mock("../../src/utils/prismaClient", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/middlewares/isAuthenticated", () => ({
+  isAuthenticated: jest.fn((req: Request, res: Response, next: NextFunction) =>
+    next()
+  ),
+}));
+
+const mockPrisma = jest.mocked(prisma);
+const mockIsAuthenticated = jest.mocked(
+  require("../../src/middlewares/isAuthenticated").isAuthenticated
+);
+
+// --- Datos de Prueba ---
+const userId = "user-uuid-123";
+const mockUser = {
+  id: userId,
+  firstName: "Juan",
+  lastName: "Perez",
+  email: "juan@test.com",
+  passwordHash: "hash_secreto_123",
+  role: Role.CUSTOMER,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// DTO (sin hash)
+const mockUserDto = {
+  id: userId,
+  firstName: "Juan",
+  lastName: "Perez",
+  email: "juan@test.com",
+  role: Role.CUSTOMER,
+  createdAt: mockUser.createdAt.toISOString(),
+  updatedAt: mockUser.updatedAt.toISOString(),
+};
+
+describe("Users API Integration Tests (/users/me)", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // Inyecta el usuario en la sesión para cada test
+    mockIsAuthenticated.mockImplementation(
+      (req: Request, _res: Response, next: NextFunction) => {
+        (req as any).session = { user: { id: userId } };
+        next();
+      }
+    );
+  });
+
+  describe("GET /users/me", () => {
+    test("debería retornar el perfil del usuario autenticado (200)", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+      const response = await request(app).get("/users/me").expect(200);
+
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(response.body.status).toBe("success");
+      expect(response.body.data).toEqual(mockUserDto);
+    });
+
+    test("debería retornar 404 si el usuario de la sesión no existe en BD", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const response = await request(app).get("/users/me").expect(404);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe("Usuario no encontrado");
+    });
+
+    test("debería retornar 401 si no está autenticado", async () => {
+      mockIsAuthenticated.mockImplementationOnce(
+        (req: Request, res: Response, next: NextFunction) => {
+          next(new AppError("No autenticado", 401));
+        }
+      );
+      const response = await request(app).get("/users/me").expect(401);
+      expect(response.body.message).toBe("No autenticado");
+    });
+  });
+
+  describe("PATCH /users/me", () => {
+    const updateData = { firstName: "Pedro" };
+    const updatedUser = { ...mockUser, ...updateData };
+    const updatedUserDto = { ...mockUserDto, ...updateData };
+
+    test("debería actualizar el perfil del usuario (200)", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.user.update.mockResolvedValue(updatedUser);
+
+      const response = await request(app)
+        .patch("/users/me")
+        .send(updateData)
+        .expect(200);
+
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateData,
+      });
+      expect(response.body.status).toBe("success");
+      expect(response.body.data).toEqual(updatedUserDto);
+    });
+
+    test("debería actualizar el email si está disponible (200)", async () => {
+      const updateEmailData = { email: "nuevo@test.com" };
+      const updatedUser = { ...mockUser, ...updateEmailData };
+      const updatedUserDto = { ...mockUserDto, ...updateEmailData };
+
+      mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+      mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+      mockPrisma.user.update.mockResolvedValue(updatedUser);
+
+      const response = await request(app)
+        .patch("/users/me")
+        .send(updateEmailData)
+        .expect(200);
+
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: "nuevo@test.com" },
+      });
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateEmailData,
+      });
+      expect(response.body.data).toEqual(updatedUserDto);
+    });
+
+    test("debería retornar 400 si los datos de validación son incorrectos", async () => {
+      const invalidData = { email: "esto-no-es-un-email" };
+      const response = await request(app)
+        .patch("/users/me")
+        .send(invalidData)
+        .expect(400);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toContain("Error de validación");
+      expect(response.body.errors).toBeInstanceOf(Array);
+      expect(response.body.errors[0].path).toEqual(["body", "email"]);
+    });
+
+    test("debería retornar 409 si el email ya está en uso por otro usuario", async () => {
+      const updateEmailData = { email: "otro@test.com" };
+      const otherUser = { ...mockUser, id: "user-456", email: "otro@test.com" };
+
+      mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+      mockPrisma.user.findUnique.mockResolvedValueOnce(otherUser);
+
+      const response = await request(app)
+        .patch("/users/me")
+        .send(updateEmailData)
+        .expect(409);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe(
+        "El correo electrónico ya está en uso"
+      );
+    });
+
+    test("debería retornar 404 si el usuario a actualizar no existe", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const response = await request(app)
+        .patch("/users/me")
+        .send(updateData)
+        .expect(404);
+
+      expect(response.body.message).toBe("Usuario no encontrado");
+    });
+  });
+
+  describe("DELETE /users/me", () => {
+    test("debería eliminar la cuenta del usuario (204)", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.user.delete.mockResolvedValue(mockUser);
+
+      await request(app).delete("/users/me").expect(204);
+
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+    });
+
+    test("debería retornar 404 si el usuario a eliminar no existe", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const response = await request(app).delete("/users/me").expect(404);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe("Usuario no encontrado");
+      expect(mockPrisma.user.delete).not.toHaveBeenCalled();
+    });
+
+    test("debería retornar 401 si no está autenticado", async () => {
+      mockIsAuthenticated.mockImplementationOnce(
+        (req: Request, res: Response, next: NextFunction) => {
+          next(new AppError("No autenticado", 401));
+        }
+      );
+      await request(app).delete("/users/me").expect(401);
+    });
+  });
+});

--- a/tests/unit/services/users.test.ts
+++ b/tests/unit/services/users.test.ts
@@ -1,0 +1,179 @@
+import { UsersService } from "../../../src/services/users";
+import { UsersModel } from "../../../src/models/users";
+import { AppError } from "../../../src/errors/AppError";
+import { Role } from "@prisma/client";
+
+jest.mock("../../../src/models/users");
+
+const mockUsersModel = jest.mocked(UsersModel);
+
+// --- Datos de Prueba ---
+const userId = "user-uuid-123";
+const mockUser = {
+  id: userId,
+  firstName: "Juan",
+  lastName: "Perez",
+  email: "juan@test.com",
+  passwordHash: "hash_secreto_123",
+  role: Role.CUSTOMER,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// DTO = Data Transfer Object (lo que devolvemos al cliente, sin el hash)
+const mockUserDto = {
+  id: userId,
+  firstName: "Juan",
+  lastName: "Perez",
+  email: "juan@test.com",
+  role: Role.CUSTOMER,
+  createdAt: mockUser.createdAt,
+  updatedAt: mockUser.updatedAt,
+};
+
+describe("UsersService", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("getProfile", () => {
+    test("debería retornar el perfil del usuario sin el hash de contraseña", async () => {
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+
+      const result = await UsersService.getProfile(userId);
+
+      expect(mockUsersModel.getProfile).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(mockUserDto);
+      expect(result).not.toHaveProperty("passwordHash");
+    });
+
+    test("debería lanzar AppError 404 si el usuario no se encuentra", async () => {
+      mockUsersModel.getProfile.mockResolvedValue(null);
+
+      await expect(UsersService.getProfile(userId)).rejects.toThrow(AppError);
+      await expect(UsersService.getProfile(userId)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Usuario no encontrado",
+      });
+    });
+  });
+
+  describe("updateProfile", () => {
+    test("debería actualizar el perfil (sin cambiar email) y retornar el DTO", async () => {
+      const updateData = { lastName: "Gomez" };
+      const updatedUser = { ...mockUser, lastName: "Gomez" };
+      const updatedUserDto = { ...mockUserDto, lastName: "Gomez" };
+
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+      mockUsersModel.updateProfile.mockResolvedValue(updatedUser);
+
+      const result = await UsersService.updateProfile(userId, updateData);
+
+      expect(mockUsersModel.getProfile).toHaveBeenCalledWith(userId);
+
+      expect(mockUsersModel.getByEmail).not.toHaveBeenCalled();
+      expect(mockUsersModel.updateProfile).toHaveBeenCalledWith(
+        userId,
+        updateData
+      );
+      expect(result).toEqual(updatedUserDto);
+      expect(result).not.toHaveProperty("passwordHash");
+    });
+
+    test("debería actualizar el perfil (cambiando email) si el email está disponible", async () => {
+      const updateData = { email: "nuevo@test.com" };
+      const updatedUser = { ...mockUser, email: "nuevo@test.com" };
+      const updatedUserDto = { ...mockUserDto, email: "nuevo@test.com" };
+
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+      mockUsersModel.getByEmail.mockResolvedValue(null);
+      mockUsersModel.updateProfile.mockResolvedValue(updatedUser);
+
+      const result = await UsersService.updateProfile(userId, updateData);
+
+      expect(mockUsersModel.getProfile).toHaveBeenCalledWith(userId);
+      expect(mockUsersModel.getByEmail).toHaveBeenCalledWith("nuevo@test.com");
+      expect(mockUsersModel.updateProfile).toHaveBeenCalledWith(
+        userId,
+        updateData
+      );
+      expect(result).toEqual(updatedUserDto);
+    });
+
+    test("debería lanzar AppError 409 si el email a actualizar ya está en uso", async () => {
+      const updateData = { email: "otro@test.com" };
+      const otherUser = { ...mockUser, id: "user-456", email: "otro@test.com" };
+
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+      mockUsersModel.getByEmail.mockResolvedValue(otherUser);
+
+      await expect(
+        UsersService.updateProfile(userId, updateData)
+      ).rejects.toThrow(AppError);
+      await expect(
+        UsersService.updateProfile(userId, updateData)
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: "El correo electrónico ya está en uso",
+      });
+      expect(mockUsersModel.updateProfile).not.toHaveBeenCalled();
+    });
+
+    test("debería no hacer nada si el email es el mismo del usuario actual", async () => {
+      const updateData = { email: "juan@test.com" };
+      const updatedUser = { ...mockUser };
+      const updatedUserDto = { ...mockUserDto };
+
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+      mockUsersModel.updateProfile.mockResolvedValue(updatedUser);
+
+      const result = await UsersService.updateProfile(userId, updateData);
+
+      expect(mockUsersModel.getProfile).toHaveBeenCalledWith(userId);
+      expect(mockUsersModel.getByEmail).not.toHaveBeenCalled();
+      expect(mockUsersModel.updateProfile).toHaveBeenCalledWith(
+        userId,
+        updateData
+      );
+      expect(result).toEqual(updatedUserDto);
+    });
+
+    test("debería lanzar AppError 404 si el usuario a actualizar no existe", async () => {
+      mockUsersModel.getProfile.mockResolvedValue(null);
+
+      await expect(UsersService.updateProfile(userId, {})).rejects.toThrow(
+        AppError
+      );
+      await expect(
+        UsersService.updateProfile(userId, {})
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Usuario no encontrado",
+      });
+    });
+  });
+
+  describe("deleteUser", () => {
+    test("debería eliminar al usuario si existe", async () => {
+      mockUsersModel.getProfile.mockResolvedValue(mockUser);
+      mockUsersModel.delete.mockResolvedValue(mockUser);
+
+      const result = await UsersService.deleteUser(userId);
+
+      expect(mockUsersModel.getProfile).toHaveBeenCalledWith(userId);
+      expect(mockUsersModel.delete).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(mockUser);
+    });
+
+    test("debería lanzar AppError 404 si el usuario a eliminar no existe", async () => {
+      mockUsersModel.getProfile.mockResolvedValue(null);
+
+      await expect(UsersService.deleteUser(userId)).rejects.toThrow(AppError);
+      await expect(UsersService.deleteUser(userId)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Usuario no encontrado",
+      });
+      expect(mockUsersModel.delete).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request introduces the functionality for an authenticated user to manage their own profile. It provides secure endpoints for fetching, partially updating (PATCH), and deleting their user account.

The implementation creates a new `UsersModel` and `UsersService` (separate from `AuthModel`) to handle profile-specific business logic, such as checking for email conflicts on update and stripping the password hash from responses.

## Key Changes

### 1. 🏗️ Core Logic & Schemas
* **Models (`models/users.ts`):** Added `UsersModel` with methods for `getProfile`, `getByEmail`, `updateProfile`, and `delete`.
* **Services (`services/users.ts`):** Added `UsersService` with business logic for:
    * `getProfile`: Fetches user data and strips the `passwordHash`.
    * `updateProfile`: Handles partial updates, including a check for email conflicts (409) *only* if the email is being changed.
    * `deleteUser`: Handles existence check (404) before deletion.
* **Schemas (`schemas/users/index.ts`):** Added a Zod schema (`patchUserSchema`) using `.partial()` to validate optional fields for `PATCH /users/me`.

### 2. 🔌 API Layer
* **Controllers (`controllers/users.ts`):** Implemented `UsersController` with methods (`getProfile`, `updateProfile`, `deleteUser`) that read `userId` from session and `validatedData` from the request.
* **Routes (`routes/users.ts`, `routes/index.ts`):** Defined the API routes under `/users/me` (`GET`, `PATCH`, `DELETE`). All routes are protected with `isAuthenticated` and `validateRequest`.

### 3. ✅ Testing
* **Unit Tests (`tests/unit/services/users.test.ts`):** Added comprehensive unit tests for `UsersService`, verifying all logic branches and error cases.
* **Integration Tests (`tests/integration/users.test.ts`):** Added integration tests for all `/users/me` endpoints, mocking the Prisma client and session. Verifies success (200, 204) and error (400, 401, 404, 409) responses.