### PR TITLE
feat(addresses): Implement user address book functionality

### DIFF
--- a/src/controllers/addresses.ts
+++ b/src/controllers/addresses.ts
@@ -62,7 +62,7 @@ export class AddressesController {
       const userId = req.session!.user!.id as string;
       const { id: addressId } = req.validatedData!.params as { id: string };
 
-      await AddressesService.deleteAddress(userId, addressId);
+      await AddressesService.deleteAddress(addressId, userId);
 
       return res.status(204).send();
     } catch (error) {

--- a/src/controllers/addresses.ts
+++ b/src/controllers/addresses.ts
@@ -1,0 +1,72 @@
+import { Request, Response, NextFunction } from "express";
+import { AddressesService } from "../services/addresses";
+import { CreateAddressInput, UpdateAddressInput } from "../schemas/addresses";
+
+export class AddressesController {
+  static async getAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const result = await AddressesService.listUserAddresses(userId);
+      return res.json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async getById(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const { id: addressId } = req.validatedData!.params as { id: string };
+
+      const result = await AddressesService.getAddressById(addressId, userId);
+
+      return res.json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async createAddress(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const addressData = req.validatedData!.body as CreateAddressInput;
+
+      const result = await AddressesService.createAddress(userId, addressData);
+
+      return res.status(201).json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async updateAddress(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const { id: addressId } = req.validatedData!.params as { id: string };
+      const addressData = req.validatedData!.body as UpdateAddressInput;
+
+      const result = await AddressesService.updateAddress(
+        addressId,
+        userId,
+        addressData
+      );
+
+      return res.json({ status: "success", data: result });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  static async deleteAddress(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.session!.user!.id as string;
+      const { id: addressId } = req.validatedData!.params as { id: string };
+
+      await AddressesService.deleteAddress(userId, addressId);
+
+      return res.status(204).send();
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/src/models/addresses.ts
+++ b/src/models/addresses.ts
@@ -1,0 +1,82 @@
+import { Prisma } from "@prisma/client";
+import { CreateAddressInput, UpdateAddressInput } from "../schemas/addresses";
+import { prisma } from "../utils/prismaClient";
+
+export class AddressesModel {
+  static async getAllByUserId(userId: string) {
+    return await prisma.address.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  static async getById(id: string) {
+    return await prisma.address.findUnique({
+      where: { id },
+    });
+  }
+
+  static async create(data: CreateAddressInput, userId: string) {
+    if (!data.isDefault) {
+      return await prisma.address.create({
+        data: {
+          ...data,
+          user: { connect: { id: userId } },
+        } as Prisma.AddressCreateInput,
+      });
+    }
+
+    return prisma.$transaction(async (tx) => {
+      await tx.address.updateMany({
+        where: { userId: userId, isDefault: true },
+        data: { isDefault: false },
+      });
+
+      const newAddress = await tx.address.create({
+        data: {
+          ...data,
+          user: { connect: { id: userId } },
+        } as Prisma.AddressCreateInput,
+      });
+
+      return newAddress;
+    });
+  }
+
+  static async update(
+    addressId: string,
+    userId: string,
+    data: UpdateAddressInput
+  ) {
+    if (data.isDefault !== true) {
+      return await prisma.address.update({
+        where: { id: addressId },
+        data: data as Prisma.AddressUpdateInput,
+      });
+    }
+
+    return prisma.$transaction(async (tx) => {
+      await tx.address.updateMany({
+        where: {
+          userId: userId,
+          isDefault: true,
+          id: { not: addressId },
+        },
+        data: { isDefault: false },
+      });
+
+      const updatedAddress = await tx.address.update({
+        where: { id: addressId },
+        data: data as Prisma.AddressUpdateInput,
+      });
+
+      return updatedAddress;
+    });
+  }
+
+  static async delete(addressId: string) {
+    return await prisma.address.delete({
+      where: { id: addressId },
+    });
+  }
+}

--- a/src/routes/addresses.ts
+++ b/src/routes/addresses.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { AddressesController } from "../controllers/addresses";
+import { validateRequest } from "../middlewares/validateRequest";
+import { createAddressSchema, updateAddressSchema } from "../schemas/addresses";
+import { idSchema } from "../schemas/globals";
+
+const router = Router();
+
+router.get("/", AddressesController.getAll);
+
+router.post(
+  "/",
+  validateRequest(createAddressSchema),
+  AddressesController.createAddress
+);
+
+router.get("/:id", validateRequest(idSchema), AddressesController.getById);
+
+router.patch(
+  "/:id",
+  validateRequest(updateAddressSchema),
+  AddressesController.updateAddress
+);
+
+router.delete(
+  "/:id",
+  validateRequest(idSchema),
+  AddressesController.deleteAddress
+);
+
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -3,6 +3,7 @@ import { isAuthenticated } from "../middlewares/isAuthenticated";
 import { UsersController } from "../controllers/users";
 import { validateRequest } from "../middlewares/validateRequest";
 import { patchUserSchemaValidation } from "../schemas/users";
+import addressesRouter from "./addresses";
 
 const router = Router();
 
@@ -16,5 +17,7 @@ router.patch(
 );
 
 router.delete("/me", isAuthenticated, UsersController.deleteUser);
+
+router.use("/me/addresses", isAuthenticated, addressesRouter);
 
 export default router;

--- a/src/schemas/addresses/index.ts
+++ b/src/schemas/addresses/index.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { idSchema } from "../globals";
+
+const bodySchema = z.object({
+  addressLine1: z
+    .string()
+    .min(1, "La dirección no puede estar vacía")
+    .max(255, "La dirección debe tener como máximo 255 caracteres"),
+  addressLine2: z
+    .string()
+    .max(255, "La dirección debe tener como máximo 255 caracteres")
+    .nullable(),
+  city: z
+    .string()
+    .min(1, "La ciudad no puede estar vacía")
+    .max(100, "La ciudad debe tener como máximo 100 caracteres"),
+  state: z
+    .string()
+    .min(1, "El estado no puede estar vacío")
+    .max(100, "El estado debe tener como máximo 100 caracteres"),
+  postalCode: z
+    .string()
+    .min(1, "El código postal no puede estar vacío")
+    .max(20, "El código postal debe tener como máximo 20 caracteres"),
+  country: z
+    .string()
+    .min(1, "El país no puede estar vacío")
+    .max(100, "El país debe tener como máximo 100 caracteres"),
+  isDefault: z.boolean().optional(),
+});
+
+export const createAddressSchema = z.object({
+  body: bodySchema,
+});
+
+export const updateAddressSchema = idSchema.extend({
+  body: bodySchema.partial(),
+});
+
+export type CreateAddressInput = z.infer<typeof createAddressSchema>["body"];
+export type UpdateAddressInput = z.infer<typeof updateAddressSchema>["body"];

--- a/src/services/addresses.ts
+++ b/src/services/addresses.ts
@@ -1,0 +1,46 @@
+import { AppError } from "../errors/AppError";
+import { AddressesModel } from "../models/addresses";
+import { CreateAddressInput, UpdateAddressInput } from "../schemas/addresses";
+
+export class AddressesService {
+  static async listUserAddresses(userId: string) {
+    return await AddressesModel.getAllByUserId(userId);
+  }
+
+  static async getAddressById(addressId: string, userId: string) {
+    const address = await AddressesModel.getById(addressId);
+
+    if (!address || address.userId !== userId) {
+      throw new AppError("No se encontró la dirección solicitada", 404);
+    }
+
+    return address;
+  }
+
+  static async createAddress(userId: string, data: CreateAddressInput) {
+    return await AddressesModel.create(data, userId);
+  }
+
+  static async updateAddress(
+    addressId: string,
+    userId: string,
+    data: UpdateAddressInput
+  ) {
+    await this.getAddressById(addressId, userId);
+
+    return await AddressesModel.update(addressId, userId, data);
+  }
+
+  static async deleteAddress(addressId: string, userId: string) {
+    const address = await this.getAddressById(addressId, userId);
+
+    if (address.isDefault) {
+      throw new AppError(
+        "No se puede eliminar la dirección predeterminada",
+        400
+      );
+    }
+
+    return await AddressesModel.delete(addressId);
+  }
+}

--- a/tests/integration/addresses.test.ts
+++ b/tests/integration/addresses.test.ts
@@ -1,0 +1,357 @@
+import request from "supertest";
+import { Request, Response, NextFunction } from "express";
+import app from "../../src/app";
+import { prisma } from "../../src/utils/prismaClient";
+import { AppError } from "../../src/errors/AppError";
+
+// --- Mocking Dependencias ---
+jest.mock("../../src/utils/prismaClient", () => ({
+  prisma: {
+    address: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    $transaction: jest.fn((callback) => callback(prisma)),
+  },
+}));
+
+jest.mock("../../src/middlewares/isAuthenticated", () => ({
+  isAuthenticated: jest.fn((req: Request, res: Response, next: NextFunction) =>
+    next()
+  ),
+}));
+
+const mockPrisma = jest.mocked(prisma);
+const mockIsAuthenticated = jest.mocked(
+  require("../../src/middlewares/isAuthenticated").isAuthenticated
+);
+
+// --- Datos de Prueba ---
+const userId = "user-uuid-123";
+const addressId = "f8bbe5d8-4b45-48da-a0f1-c64484bb8426";
+const mockAddress = {
+  id: addressId,
+  addressLine1: "Calle Falsa 123",
+  addressLine2: null,
+  city: "Springfield",
+  state: "Provincia",
+  postalCode: "5000",
+  country: "Argentina",
+  isDefault: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  userId: userId,
+};
+const mockDefaultAddress = {
+  ...mockAddress,
+  id: "c2a9b3d1-4f6a-4b8a-9c0d-3b1a2b3c4d5e",
+  isDefault: true,
+};
+const mockAddressDto = {
+  ...mockAddress,
+  createdAt: mockAddress.createdAt.toISOString(),
+  updatedAt: mockAddress.updatedAt.toISOString(),
+};
+const addressPayload = {
+  addressLine1: "Calle Nueva 456",
+  addressLine2: null,
+  city: "Ciudad Nueva",
+  state: "Estado Nuevo",
+  postalCode: "5001",
+  country: "Argentina",
+  isDefault: false,
+};
+
+describe("Addresses API Integration Tests (/users/me/addresses)", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // Inyecta el usuario en la sesión para cada test
+    mockIsAuthenticated.mockImplementation(
+      (req: Request, _res: Response, next: NextFunction) => {
+        (req as any).session = { user: { id: userId } };
+        next();
+      }
+    );
+    // Configura el mock de $transaction para que llame al callback por defecto
+    mockPrisma.$transaction.mockImplementation(async (callback) =>
+      callback(prisma)
+    );
+  });
+
+  describe("GET /", () => {
+    test("debería retornar la lista de direcciones del usuario (200)", async () => {
+      mockPrisma.address.findMany.mockResolvedValue([mockAddress]);
+
+      const response = await request(app)
+        .get("/users/me/addresses")
+        .expect(200);
+
+      expect(response.body.status).toBe("success");
+      expect(response.body.data).toEqual([mockAddressDto]);
+      expect(mockPrisma.address.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId } })
+      );
+    });
+
+    test("debería retornar 401 si no está autenticado", async () => {
+      mockIsAuthenticated.mockImplementationOnce(
+        (req: Request, res: Response, next: NextFunction) => {
+          next(new AppError("No autenticado", 401));
+        }
+      );
+      const response = await request(app)
+        .get("/users/me/addresses")
+        .expect(401);
+      expect(response.body.message).toBe("No autenticado");
+    });
+  });
+
+  describe("POST /", () => {
+    test("debería crear una nueva dirección (201)", async () => {
+      const newAddress = { ...mockAddress, ...addressPayload, id: "new-uuid" };
+      mockPrisma.address.create.mockResolvedValue(newAddress);
+
+      const response = await request(app)
+        .post("/users/me/addresses")
+        .send(addressPayload)
+        .expect(201);
+
+      expect(mockPrisma.address.create).toHaveBeenCalled();
+      expect(response.body.status).toBe("success");
+      expect(response.body.data.addressLine1).toBe("Calle Nueva 456");
+    });
+
+    test("debería manejar 'isDefault' y llamar a $transaction (201)", async () => {
+      const defaultPayload = { ...addressPayload, isDefault: true };
+      const newDefaultAddress = {
+        ...mockAddress,
+        ...defaultPayload,
+        id: "new-uuid",
+      };
+
+      mockPrisma.address.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.address.create.mockResolvedValue(newDefaultAddress);
+
+      const response = await request(app)
+        .post("/users/me/addresses")
+        .send(defaultPayload)
+        .expect(201);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled(); // Verifica que se usó la transacción
+      expect(mockPrisma.address.updateMany).toHaveBeenCalled(); // Verif. que se reseteó el default
+      expect(mockPrisma.address.create).toHaveBeenCalled();
+      expect(response.body.data.isDefault).toBe(true);
+    });
+
+    test("debería retornar 400 si faltan datos (validation)", async () => {
+      const invalidPayload = { ...addressPayload, city: "" }; // city no puede ser vacío
+      const response = await request(app)
+        .post("/users/me/addresses")
+        .send(invalidPayload)
+        .expect(400);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toContain("Error de validación");
+    });
+  });
+
+  describe("GET /:id", () => {
+    test("debería retornar una dirección específica del usuario (200)", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(mockAddress);
+
+      const response = await request(app)
+        .get(`/users/me/addresses/${addressId}`)
+        .expect(200);
+
+      expect(mockPrisma.address.findUnique).toHaveBeenCalledWith({
+        where: { id: addressId },
+      });
+      expect(response.body.status).toBe("success");
+      expect(response.body.data).toEqual(mockAddressDto);
+    });
+
+    test("debería retornar 404 si la dirección no existe", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(null);
+      const response = await request(app)
+        .get(`/users/me/addresses/${addressId}`)
+        .expect(404);
+      expect(response.body.message).toBe(
+        "No se encontró la dirección solicitada"
+      );
+    });
+
+    test("debería retornar 404 si la dirección no pertenece al usuario", async () => {
+      const otherUserAddress = { ...mockAddress, userId: "other-user-id" };
+      mockPrisma.address.findUnique.mockResolvedValue(otherUserAddress);
+
+      const response = await request(app)
+        .get(`/users/me/addresses/${addressId}`)
+        .expect(404);
+      expect(response.body.message).toBe(
+        "No se encontró la dirección solicitada"
+      );
+    });
+  });
+
+  describe("PATCH /:id", () => {
+    const patchData = { city: "Ciudad Actualizada" };
+    const mockAddressForPatch = { ...mockAddress, id: addressId };
+    const updatedAddress = { ...mockAddressForPatch, ...patchData };
+
+    test("debería actualizar una dirección (200)", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(mockAddressForPatch); 
+      mockPrisma.address.update.mockResolvedValue(updatedAddress); 
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(patchData)
+        .expect(200);
+
+      expect(mockPrisma.address.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: addressId },
+          data: patchData,
+        })
+      );
+      expect(response.body.data.city).toBe("Ciudad Actualizada");
+      expect(response.body.status).toBe("success");
+    });
+
+    test("debería manejar 'isDefault: true' y llamar a $transaction (200)", async () => {
+      const patchDefaultData = { isDefault: true };
+      const updatedDefaultAddress = { ...mockAddressForPatch, isDefault: true };
+
+      mockPrisma.address.findUnique.mockResolvedValue(mockAddressForPatch); 
+      mockPrisma.address.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.address.update.mockResolvedValue(updatedDefaultAddress);
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(patchDefaultData)
+        .expect(200);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled(); 
+      expect(mockPrisma.address.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId, isDefault: true, id: { not: addressId } },
+        })
+      );
+      expect(response.body.data.isDefault).toBe(true);
+    });
+
+    test("debería retornar 400 si el ID es inválido (no UUID)", async () => {
+      const response = await request(app)
+        .patch("/users/me/addresses/abc")
+        .send(patchData)
+        .expect(400);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toContain("Error de validación");
+    });
+
+    test("debería retornar 400 si el body es inválido (validation)", async () => {
+      const invalidData = { city: "" }; 
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(invalidData)
+        .expect(400);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.errors[0].path).toEqual(["body", "city"]);
+    });
+
+    test("debería retornar 401 si no está autenticado", async () => {
+      mockIsAuthenticated.mockImplementationOnce(
+        (req: Request, res: Response, next: NextFunction) => {
+          next(new AppError("No autenticado", 401));
+        }
+      );
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(patchData)
+        .expect(401);
+
+      expect(response.body.message).toBe("No autenticado");
+    });
+
+    test("debería retornar 404 si la dirección no existe", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(null); 
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(patchData)
+        .expect(404);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe(
+        "No se encontró la dirección solicitada"
+      );
+      expect(mockPrisma.address.update).not.toHaveBeenCalled();
+    });
+
+    test("debería retornar 404 si la dirección no pertenece al usuario", async () => {
+      const otherUserAddress = {
+        ...mockAddressForPatch,
+        userId: "otro-usuario-id",
+      };
+      mockPrisma.address.findUnique.mockResolvedValue(otherUserAddress); 
+
+      const response = await request(app)
+        .patch(`/users/me/addresses/${addressId}`)
+        .send(patchData)
+        .expect(404);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe(
+        "No se encontró la dirección solicitada"
+      );
+      expect(mockPrisma.address.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /:id", () => {
+    test("debería eliminar una dirección (204)", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(mockAddress);
+      mockPrisma.address.delete.mockResolvedValue(mockAddress);
+
+      await request(app).delete(`/users/me/addresses/${addressId}`).expect(204);
+
+      expect(mockPrisma.address.delete).toHaveBeenCalledWith({
+        where: { id: addressId },
+      });
+    });
+
+    test("debería retornar 400 si se intenta eliminar la dirección predeterminada", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(mockDefaultAddress); // Es default
+
+      const response = await request(app)
+        .delete(`/users/me/addresses/${mockDefaultAddress.id}`)
+        .expect(400);
+
+      expect(response.body.status).toBe("error");
+      expect(response.body.message).toBe(
+        "No se puede eliminar la dirección predeterminada"
+      );
+      expect(mockPrisma.address.delete).not.toHaveBeenCalled();
+    });
+
+    test("debería retornar 404 si la dirección a eliminar no existe", async () => {
+      mockPrisma.address.findUnique.mockResolvedValue(null);
+
+      const response = await request(app)
+        .delete(`/users/me/addresses/${addressId}`)
+        .expect(404);
+
+      expect(response.body.message).toBe(
+        "No se encontró la dirección solicitada"
+      );
+      expect(mockPrisma.address.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/services/addresses.test.ts
+++ b/tests/unit/services/addresses.test.ts
@@ -1,0 +1,188 @@
+// tests/unit/services/addresses.test.ts
+
+import { AddressesService } from "../../../src/services/addresses";
+import { AddressesModel } from "../../../src/models/addresses";
+import { AppError } from "../../../src/errors/AppError";
+
+jest.mock("../../../src/models/addresses");
+
+const mockAddressesModel = jest.mocked(AddressesModel);
+
+// --- Datos de Prueba ---
+const userId = "user-uuid-123";
+const otherUserId = "user-uuid-456";
+const addressId = "addr-uuid-789";
+
+const mockAddress = {
+  id: addressId,
+  addressLine1: "Calle Falsa 123",
+  addressLine2: null,
+  city: "Springfield",
+  state: "Provincia",
+  postalCode: "5000",
+  country: "Argentina",
+  isDefault: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  userId: userId,
+};
+
+const mockDefaultAddress = {
+  ...mockAddress,
+  id: "addr-uuid-default",
+  isDefault: true,
+};
+
+const mockAddressInput = {
+  addressLine1: "Calle Nueva 456",
+  addressLine2: null,
+  city: "Ciudad Nueva",
+  state: "Estado Nuevo",
+  postalCode: "5001",
+  country: "Argentina",
+  isDefault: false,
+};
+
+describe("AddressesService", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("listUserAddresses", () => {
+    test("debería retornar una lista de direcciones del usuario", async () => {
+      mockAddressesModel.getAllByUserId.mockResolvedValue([
+        mockAddress,
+        mockDefaultAddress,
+      ]);
+
+      const result = await AddressesService.listUserAddresses(userId);
+
+      expect(mockAddressesModel.getAllByUserId).toHaveBeenCalledWith(userId);
+      expect(result).toEqual([mockAddress, mockDefaultAddress]);
+    });
+  });
+
+  describe("getAddressById", () => {
+    test("debería retornar una dirección si existe y pertenece al usuario", async () => {
+      mockAddressesModel.getById.mockResolvedValue(mockAddress);
+
+      const result = await AddressesService.getAddressById(addressId, userId);
+
+      expect(mockAddressesModel.getById).toHaveBeenCalledWith(addressId);
+      expect(result).toEqual(mockAddress);
+    });
+
+    test("debería lanzar AppError 404 si la dirección no existe", async () => {
+      mockAddressesModel.getById.mockResolvedValue(null);
+
+      await expect(
+        AddressesService.getAddressById(addressId, userId)
+      ).rejects.toThrow(AppError);
+      await expect(
+        AddressesService.getAddressById(addressId, userId)
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: "No se encontró la dirección solicitada",
+      });
+    });
+
+    test("debería lanzar AppError 404 si la dirección no pertenece al usuario", async () => {
+      mockAddressesModel.getById.mockResolvedValue(mockAddress);
+
+      await expect(
+        AddressesService.getAddressById(addressId, otherUserId)
+      ).rejects.toThrow(AppError);
+      await expect(
+        AddressesService.getAddressById(addressId, otherUserId)
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: "No se encontró la dirección solicitada",
+      });
+    });
+  });
+
+  describe("createAddress", () => {
+    test("debería llamar a AddressesModel.create", async () => {
+      mockAddressesModel.create.mockResolvedValue(mockAddress);
+
+      await AddressesService.createAddress(userId, mockAddressInput);
+
+      expect(mockAddressesModel.create).toHaveBeenCalledWith(
+        mockAddressInput,
+        userId
+      );
+    });
+  });
+
+  describe("updateAddress", () => {
+    test("debería actualizar la dirección si existe y pertenece al usuario", async () => {
+      const updateData = { city: "Nueva Ciudad" };
+      const updatedAddress = { ...mockAddress, city: "Nueva Ciudad" };
+
+      mockAddressesModel.getById.mockResolvedValue(mockAddress);
+      mockAddressesModel.update.mockResolvedValue(updatedAddress);
+
+      const result = await AddressesService.updateAddress(
+        addressId,
+        userId,
+        updateData
+      );
+
+      expect(mockAddressesModel.getById).toHaveBeenCalledWith(addressId);
+      expect(mockAddressesModel.update).toHaveBeenCalledWith(
+        addressId,
+        userId,
+        updateData
+      );
+      expect(result.city).toBe("Nueva Ciudad");
+    });
+
+    test("debería lanzar 404 si la dirección a actualizar no existe o no pertenece", async () => {
+      mockAddressesModel.getById.mockResolvedValue(null); // Falla el check
+
+      await expect(
+        AddressesService.updateAddress(addressId, userId, {})
+      ).rejects.toThrow(AppError);
+      expect(mockAddressesModel.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteAddress", () => {
+    test("debería eliminar la dirección si no es la predeterminada", async () => {
+      mockAddressesModel.getById.mockResolvedValue(mockAddress);
+      mockAddressesModel.delete.mockResolvedValue(mockAddress);
+
+      const result = await AddressesService.deleteAddress(addressId, userId);
+
+      expect(mockAddressesModel.getById).toHaveBeenCalledWith(addressId);
+      expect(mockAddressesModel.delete).toHaveBeenCalledWith(addressId);
+      expect(result).toEqual(mockAddress);
+    });
+
+    test("debería lanzar AppError 400 si se intenta eliminar la dirección predeterminada", async () => {
+      mockAddressesModel.getById.mockResolvedValue(mockDefaultAddress);
+
+      await expect(
+        AddressesService.deleteAddress(mockDefaultAddress.id, userId)
+      ).rejects.toThrow(AppError);
+      await expect(
+        AddressesService.deleteAddress(mockDefaultAddress.id, userId)
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "No se puede eliminar la dirección predeterminada",
+      });
+
+      expect(mockAddressesModel.delete).not.toHaveBeenCalled();
+    });
+
+    test("debería lanzar 404 si la dirección a eliminar no existe o no pertenece", async () => {
+      mockAddressesModel.getById.mockResolvedValue(null);
+
+      await expect(
+        AddressesService.deleteAddress(addressId, userId)
+      ).rejects.toThrow(AppError);
+
+      expect(mockAddressesModel.delete).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request introduces a complete address book management system for authenticated users. It allows users to list, create, view, update (PATCH/PUT), and delete their shipping addresses.

This feature is mounted at the `/users/me/addresses` endpoint and ensures all operations are scoped to the logged-in user. It follows our established Model-Service-Controller pattern, uses `req.validatedData` for type-safe validation, and implements critical business logic, such as managing a single "default" address.

## Key Changes

### 1. 🏗️ Core Logic & Schemas
* **Schemas (`schemas/addresses/`):** Added Zod schemas with validation and error messages for the address body (used by `POST` and `PATCH`) and for validating the address ID in URL parameters.
* **Model (`models/addresses.ts`):** Implemented `AddressModel` with methods for `getAllByUserId`, `getById`, `create`, `update`, and `delete`. Includes **`prisma.$transaction`** logic to atomically handle the `isDefault` flag, ensuring only one address can be the default at a time.
* **Service (`services/addresses.ts`):** Created `AddressService` to orchestrate business logic:
    * **Ownership Security:** The `getAddressById` method ensures an address exists *and* belongs to the authenticated user, which is then used by `update` and `delete` to enforce security.
    * **Business Rules:** Prevents the deletion of an address if it is marked as `isDefault`.

### 2. 🔌 API Layer
* **Controller (`controllers/addresses.ts`):** Implemented `AddressController` with full CRUD methods (`getAll`, `getById`, `createAddress`, `updateAddress`, `deleteAddress`). All methods read `userId` from session and use `validatedData`.
* **Routes (`routes/addresses.ts`, `routes/users.ts`):**
    * Created a new `addressesRouter` for all 5 endpoints (`GET /`, `POST /`, `GET /:id`, `PATCH /:id`, `DELETE /:id`).
    * Mounted the new router at `/users/me/addresses` within `users.ts` and protected the entire group with the `isAuthenticated` middleware.

### 3. ✅ Testing
* **Unit Tests (`tests/unit/services/addresses.test.ts`):** Added comprehensive unit tests for `AddressService`, focusing on the business logic for ownership (e.g., cannot get another user's address) and rules (e.g., cannot delete default address).
* **Integration Tests (`tests/integration/addresses.test.ts`):** Added integration tests for all `/users/me/addresses` endpoints. Verifies success cases (200, 201, 204), error handling (400 validation, 401 auth, 404 not found/not owned), and the `isDefault` transaction logic.